### PR TITLE
Add support for migrating legacy global preferences into profiles

### DIFF
--- a/MouselookHandler.lua
+++ b/MouselookHandler.lua
@@ -760,15 +760,15 @@ function MouselookHandler:OnInitialize()
   end
 
   -- See: wowace.com/addons/ace3/pages/getting-started/#w-registering-the-options
-  AceConfig:RegisterOptionsTable(modName, options)
+  AceConfig:RegisterOptionsTable("MouselookHandler", options)
 
   local profiles = AceDBOptions:GetOptionsTable(self.db)
-  AceConfigRegistry:RegisterOptionsTable(modName .. "_Profiles", profiles)
+  AceConfigRegistry:RegisterOptionsTable("MouselookHandler_Profiles", profiles)
 
-  local configFrame = AceConfigDialog:AddToBlizOptions(modName, "MouselookHandler", nil, "general")
-  AceConfigDialog:AddToBlizOptions(modName, options.args.binds.name, "MouselookHandler", "binds")
-  AceConfigDialog:AddToBlizOptions(modName, options.args.advanced.name, "MouselookHandler", "advanced")
-  AceConfigDialog:AddToBlizOptions(modName .. "_Profiles", profiles.name, "MouselookHandler")
+  local configFrame = AceConfigDialog:AddToBlizOptions("MouselookHandler", "MouselookHandler", nil, "general")
+  AceConfigDialog:AddToBlizOptions("MouselookHandler", options.args.binds.name, "MouselookHandler", "binds")
+  AceConfigDialog:AddToBlizOptions("MouselookHandler", options.args.advanced.name, "MouselookHandler", "advanced")
+  AceConfigDialog:AddToBlizOptions("MouselookHandler_Profiles", profiles.name, "MouselookHandler")
   configFrame.default = function()
     self.db:ResetProfile()
   end

--- a/MouselookHandler.toc
+++ b/MouselookHandler.toc
@@ -2,7 +2,7 @@
 ## Title: MouselookHandler
 ## Notes: Allows controlling when mouselook is started and stopped.
 ## Author: meribold (Lukas Waymann)
-## Version: 1.3.1.50400
+## Version: 1.3.50400
 ## SavedVariables: MouselookHandlerDB
 ## OptionalDeps: Ace3
 ## X-Embeds: Ace3


### PR DESCRIPTION
On start check if they have any preferences in the db.global table that need migrating to the profile system.
1. For each global preference that exists and doesn't match the default, copy it into a new "Legacy" profile.
2. Delete the old global preferences
3. If they are now using the "Default" profile and haven't modified it yet, copy the "Legacy" profile into it.

This means 
1. If they're upgrading from pre-1.3 all their custom preferences will show up and be active in the "Default" profile meaning they shouldn't need to change anything unless they want to make use of new functionality.
2. If they had custom prefs from pre-1.3, upgraded to 1.3 and made customizations to profile preferences, then finally upgraded to 1.3.1, they will still have the settings as they made them in 1.3, but they will now have a new "Legacy" profile with their pre-1.3 prefs that they can switch to or simply copy from as desired.
